### PR TITLE
Add regen schema script for making a fresh schema.rb from migrations

### DIFF
--- a/script/regen_schema
+++ b/script/regen_schema
@@ -1,0 +1,2 @@
+#! /bin/sh
+bundle exec rake db:drop db:create db:migrate RAILS_ENV=test


### PR DESCRIPTION
Just a lil script I lifted from The Clymb that I use all the time. Makes it easier to deal with lots of branches with migrations & shit. It's also nice when rebasing, since the most common conflicts in rebasing/merging are around schema.rb/structure.sql
## To test
- run `./script/regen_schema`
